### PR TITLE
fix for Intel vendor

### DIFF
--- a/lib/vendor.rs
+++ b/lib/vendor.rs
@@ -16,8 +16,8 @@ impl Vendor {
 
     const REG_INTEL: Self = Self {
         ebx: 0x756E_6547,
-        ecx: 0x4965_6E69,
-        edx: 0x6C65_746E,
+        ecx: 0x6C65_746E,
+        edx: 0x4965_6E69,
     };
 
     const REG_CENTAUR: Self = Self {


### PR DESCRIPTION
After fixing the ecx and edx values for Intel vendor, the corresponding value, which is `GenuineIntel`, parsed fine.
```sh
ruby: ~/git-repo/cpuid_dump_rs
$ ./target/release/cpuid_dump 
[Pkg: 000, Core: 008, SMT: 000, x2APIC: 016]
       [Leaf.Sub]    [EAX]      [EBX]      [ECX]      [EDX]   
====================================================================================================
  0x00000000 0x0:  0x00000020 0x756E6547 0x6C65746E 0x49656E69  [GenuineIntel]
  0x00000001 0x0:  0x000906A3 0x10800800 0x7FFAFBFF 0xBFEBFBFF  [F: 0x6, M: 0x9A, S: 0x3]
                                                                [Codename: Intel AlderLake_L (L0)]
                                                                [ProcessNode: Intel 7]
                                                                [Arch: Intel GoldenCove + Gracemont]
                                                                [APIC ID:  16, Max: 128]
                                                                [CLFlush:  64B]
                                                                [FPU] [VME] [DE] [PSE] [TSC] [MSR] 
                                                                [PAE] [MCE] [CX8] [APIC] [SEP] 
                                                                [MTRR] [PGE] [MCA] [CMOV] [PAT] 
                                                                [PSE36] [CLFLUSH] [DS] [ACPI] [MMX] 
                                                                [FXSR] [SSE] [SSE2] [SS] [HTT] [TM] 
                                                                [PBE] [SSE3] [PCLMULQDQ] [DTES64] 
                                                                [MONITOR] [DS-CPL] [VMX] [SMX] 
                                                                [EST] [TM2] [SSSE3] [SDBG] [FMA] 
                                                                [CX16] [xTPR Update Control] [PDCM] 
                                                                [PCID] [SSE4.1] [SSE4.2] [x2APIC] 
                                                                [MOVBE] [POPCNT] [TSC-Deadline] 
                                                                [AES] [XSAVE] [OSXSAVE] [AVX] 
                                                                [F16C] [RDRAND] 
  0x00000002 0x0:  0x00FEFF01 0x000000F0 0x00000000 0x00000000  
  0x00000004 0x0:  0xFC004121 0x02C0003F 0x0000003F 0x00000000  [L1D, 12_way,  48_K]
  0x00000004 0x1:  0xFC004122 0x01C0003F 0x0000003F 0x00000000  [L1I,  8_way,  32_K]
  0x00000004 0x2:  0xFC01C143 0x0240003F 0x000007FF 0x00000000  [L2U, 10_way,1.25_M]
  0x00000004 0x3:  0xFC1FC163 0x02C0003F 0x00007FFF 0x00000004  [L3U, 12_way,  24_M]
  0x00000005 0x0:  0x00000040 0x00000040 0x00000003 0x10102020  [MonitorLineSize: 64(Min), 64(Max)]
                                                                [EMX] [IBE] 
                                                                [C1 sub-state using MWAIT: 2]
                                                                [C3 sub-state using MWAIT: 2]
                                                                [C5 sub-state using MWAIT: 1]
                                                                [C7 sub-state using MWAIT: 1]
  0x00000006 0x0:  0x00DFCFF7 0x00000002 0x00000409 0x00020003  [DiditalTempSensor] [TurboBoost] 
                                                                [ARAT] [PLN] [ECMD] [PTM] [HWP] 
                                                                [HWP_Notification] 
                                                                [HWP_Activity_Window] 
                                                                [HWP_Energy_Performance_Preference] 
                                                                [HWP_Package_Level_Request] 
                                                                [TurboBoostMax] [HWP_Capabilities] 
                                                                [HWP_PECI] [Flexible_HWP] 
                                                                [FastAccessMode] [HFI] [EHFI] 
  0x00000007 0x0:  0x00000001 0x239CA7EB 0x98C007BC 0xFC18C410  [FSGSBASE] [TSC_Adjust] [BMI1] 
                                                                [AVX2] [FDP_EXCPTN_ONLY] [SMEP] 
                                                                [BMI2] [ERMS] [INVPCID] [FPU_CS_DS] 
                                                                [PQE] [RDSEED] [ADX] [SMAP] 
                                                                [CLFLUSHOPT] [CLWB] 
                                                                [ProcessorTrace] [SHA] [UMIP] [PKU] 
                                                                [OSPKE] [WAITPKG] [CET_SS] [GFNI] 
                                                                [VAES] [VPCLMULQDQ] [RDPID] [KL] 
                                                                [MOVDIRI] [MOVDIRI64B] [PKS] [FSRM] 
                                                                [MD_CLEAR] [SERIALIZE] [Hybrid] 
                                                                [ArchitecturalLBR] [CET_IBT] [IBRS] 
                                                                [STIBP] [L1D_FLUSH] [SSBD] 
  0x00000007 0x1:  0x00400810 0x00000000 0x00000000 0x00000000  [AVX-VNNI] [FSRS] [HRESET] 
  0x0000000A 0x0:  0x07300605 0x00000000 0x00000007 0x00008603  
  0x0000000B 0x0:  0x00000001 0x00000002 0x00000100 0x00000010  [LevelType: SMT, num: 2]
  0x0000000B 0x1:  0x00000007 0x00000014 0x00000201 0x00000010  [LevelType: Core, num: 20]
  0x0000000D 0x0:  0x00000207 0x00000A88 0x00000A88 0x00000000  [-XFEATURE Mask-]
                                                                [X87] [SSE] [AVX256] 
                                                                [Protection Key User] 
  0x0000000D 0x1:  0x0000000F 0x00000670 0x00019900 0x00000000  [XSAVEOPT] [XSAVEC] [XGETBV] 
                                                                [XSAVES] [CET User] [CET SuperVisor] 
  0x0000000D 0x2:  0x00000100 0x00000240 0x00000000 0x00000000  [YMMHI            save size: 256B]
  0x0000000D 0x8:  0x00000080 0x00000000 0x00000001 0x00000000  [Unknown          save size: 128B]
  0x0000000D 0x9:  0x00000008 0x00000A80 0x00000000 0x00000000  [Protection Key   save size:   8B]
  0x0000000D 0xB:  0x00000010 0x00000000 0x00000001 0x00000000  [CET User         save size:  16B]
  0x0000000D 0xC:  0x00000018 0x00000000 0x00000001 0x00000000  [CET SuperVisor   save size:  24B]
  0x00000010 0x0:  0x00000000 0x00000004 0x00000000 0x00000000  
  0x00000014 0x0:  0x00000001 0x0000005F 0x00000007 0x00000000  
  0x00000015 0x0:  0x00000002 0x0000008C 0x0249F000 0x00000000  
  0x00000016 0x0:  0x00000A8C 0x0000125C 0x00000064 0x00000000  [2700/4700/100 MHz]
  0x00000018 0x0:  0x00000008 0x00000000 0x00000000 0x00000000  
  0x00000019 0x0:  0x00000007 0x00000014 0x00000003 0x00000000  
  0x0000001A 0x0:  0x40000001 0x00000000 0x00000000 0x00000000  [Core (0x1)]
  0x0000001C 0x0:  0x4000000B 0x00000007 0x00000007 0x00000000  
  0x0000001F 0x0:  0x00000001 0x00000002 0x00000100 0x00000010  [LevelType: SMT, num: 2]
  0x0000001F 0x1:  0x00000007 0x00000014 0x00000201 0x00000010  [LevelType: Core, num: 20]
  0x0000001F 0x2:  0x00000000 0x00000000 0x00000002 0x00000010  [LevelType: Invalid, num: 0]
  0x0000001F 0x3:  0x00000000 0x00000000 0x00000003 0x00000010  [LevelType: Invalid, num: 0]
  0x0000001F 0x4:  0x00000000 0x00000000 0x00000004 0x00000010  [LevelType: Invalid, num: 0]
  0x00000020 0x0:  0x00000000 0x00000001 0x00000000 0x00000000  
  0x80000000 0x0:  0x80000008 0x00000000 0x00000000 0x00000000  
  0x80000001 0x0:  0x00000000 0x00000000 0x00000121 0x2C100800  [LAHF/SAHF] [ABM] [3DNowPrefetch] 
                                                                [SYSCALL/SYSRET] [NXbit] [Page1GB] 
                                                                [RDTSCP] [LongMode] 
  0x80000002 0x0:  0x68743231 0x6E654720 0x746E4920 0x52286C65  ["12th Gen Intel(R"]
  0x80000003 0x0:  0x6F432029 0x54286572 0x6920294D 0x32312D37  [") Core(TM) i7-12"]
  0x80000004 0x0:  0x48303037 0x00000000 0x00000000 0x00000000  ["700H            "]
  0x80000006 0x0:  0x00000000 0x00000000 0x05007040 0x00000000  
  0x80000007 0x0:  0x00000000 0x00000000 0x00000000 0x00000100  
  0x80000008 0x0:  0x00003027 0x00000000 0x00000000 0x00000000  [Address size: 39-bits physical 
                                                                               48-bits virtual]
```